### PR TITLE
FIX: 상품 리스트 조회 시 페이지 개수 오류 수정

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,10 @@ def hello():
 
     data = DB.get_items()
     total_item_count = len(data)
-    data = dict(list(data.items())[start_index:end_index])
+    if total_item_count <= ITEM_COUNT_PER_PAGE:
+        data = dict(list(data.items())[:total_item_count])
+    else:
+        data = dict(list(data.items())[start_index:end_index])
 
     return render_template(
         "index.html",
@@ -39,7 +42,10 @@ def view_items_by_continent(continent):
 
     data = DB.get_items_by_continent(continent)
     total_item_count = len(data)
-    data = dict(list(data.items())[start_index:end_index])
+    if total_item_count <= ITEM_COUNT_PER_PAGE:
+        data = dict(list(data.items())[:total_item_count])
+    else:
+        data = dict(list(data.items())[start_index:end_index])
 
     return render_template(
         "index.html",

--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ def hello():
         datas = data.items(),
         limit = ITEM_COUNT_PER_PAGE, # 한 페이지에 상품 개수
         page = page, # 현재 페이지 인덱스
-        page_count = int((total_item_count/ITEM_COUNT_PER_PAGE)+1), # 페이지 개수
+        page_count = int(math.ceil(total_item_count/ITEM_COUNT_PER_PAGE)), # 페이지 개수
         total = total_item_count) # 총 상품 개수
 
 @application.route("/<continent>/")
@@ -52,7 +52,7 @@ def view_items_by_continent(continent):
         datas = data.items(),
         limit = ITEM_COUNT_PER_PAGE, # 한 페이지에 상품 개수
         page = page, # 현재 페이지 인덱스
-        page_count = int((total_item_count/ITEM_COUNT_PER_PAGE)+1), # 페이지 개수
+        page_count = int(math.ceil(total_item_count/ITEM_COUNT_PER_PAGE)), # 페이지 개수
         total = total_item_count) # 총 상품 개수
 
 @application.route("/login")


### PR DESCRIPTION
## 💻 작업 내용
- 상품 리스트를 조회 할 때 페이지네이션 관련 부분에 오류가 있어 수정했습니다.
- 상품 전체 조회, 대륙별 조회 두 함수에서 수정사항이 있었습니다.
- 각각 두가지씩 수정했습니다.
    1) 데이터 개수가 limit보다 크지 않은 경우 처리
    2) 페이지 개수 계산 시 올림 사용

## ⭐ 리뷰 포인트
-

## 🐻 기타 사항
-
