### PR TITLE
feat : 타인의 마이페이지로 라우팅

### DIFF
--- a/app.py
+++ b/app.py
@@ -217,6 +217,28 @@ def delete_sale():
 
     return jsonify({"message": "Product deleted successfully"}), 200
 
+@application.route('/user/<user_id>')
+def user_page(user_id):
+    # 현재 로그인된 사용자
+    current_user = session.get('user_id')
+
+    # 사용자 데이터 가져오기
+    user_wishlist = DB.get_user_wishlist(user_id)
+    user_purchases = DB.get_user_purchases(user_id)
+    user_sales = DB.get_user_sales(user_id)
+
+    # 현재 사용자가 자신의 마이페이지인지 확인
+    is_own_page = (current_user == user_id)
+
+    return render_template(
+        'user_page.html',
+        is_own_page=is_own_page,
+        user_wishlist=user_wishlist,
+        user_purchases=user_purchases,
+        user_sales=user_sales,
+        user_id=user_id
+    )
+
 """
 @application.route("/mypage/profile/update", methods=["POST"])
 def update_user_info():


### PR DESCRIPTION
## 💻 작업 내용

- 타인의 프로필 사진을 누르면 그 사람의 마이페이지로 이동하는 기능
-

## ⭐ 리뷰 포인트

- 그런데 주의할 점은, 다른 사람의 마이페이지이니까 자신의 마이페이지가 아니면 일부 권한이 제한됨. 예를 들어 a는 b의 마이페이지에 들어갔을 때 구매 내역에서 상품에 대한 리뷰 남기기 버튼이 안보여야 하고, 마이페이지의 판매 내역에서 판매 미완/판매 완료 버튼이 안보여야 함.
- 위 사항은 프론트에서 버튼 안보이게 구현 부탁드립니다.

## 🐻 기타 사항

-
-
