### PR TITLE
FEAT: 판매 미완 기능 구현

### DIFF
--- a/app.py
+++ b/app.py
@@ -415,3 +415,50 @@ def mark_as_sold():
 
     return redirect(url_for("mypage"))
 
+@application.route("/mark_as_unsold", methods=["POST"])
+def mark_as_unsold(product_id):
+    if not session.get("user_id"):
+        return abort(403)  # 로그인되지 않은 경우 접근 불가
+
+    seller_id = session["user_id"]  # 현재 로그인된 판매자 ID
+
+    # 판매자 확인
+    product = DB.get_item_byname(product_id)
+    if product.get("sellerId") != seller_id:
+        flash("이 상품에 대한 권한이 없습니다.", "error")
+        return redirect(url_for("mypage"))
+
+    # 판매 미완료 처리
+    if DB.mark_item_as_unsold(product_id):
+        flash(f"상품 {product_id}이(가) 판매 미완료 상태로 변경되었습니다.", "success")
+    else:
+        flash("판매 미완료 처리 중 문제가 발생했습니다.", "error")
+
+    return redirect(url_for("mypage"))
+
+@application.route("/mark_as_sold", methods=["POST"])
+def mark_as_sold():
+    if not session.get("user_id"):
+        return abort(403)  # 로그인되지 않은 경우 접근 불가
+
+    seller_id = session["user_id"]  # 현재 로그인된 판매자 ID
+    product_id = request.form.get("product_id")
+    buyer_id = request.form.get("buyer_id")
+
+    if not product_id or not buyer_id:
+        flash("상품 ID와 구매자 ID를 모두 입력해주세요.", "error")
+        return redirect(url_for("mypage"))  # 마이페이지로 리디렉션
+
+    # 판매자 확인
+    product = DB.get_item_byname(product_id)
+    if product.get("sellerId") != seller_id:
+        flash("이 상품에 대한 권한이 없습니다.", "error")
+        return redirect(url_for("mypage"))
+
+    # 판매 완료 처리
+    if DB.mark_item_as_sold(product_id, buyer_id):
+        flash(f"상품 {product_id}이(가) {buyer_id}에게 판매 완료 처리되었습니다.", "success")
+    else:
+        flash("판매 완료 처리 중 문제가 발생했습니다.", "error")
+
+    return redirect(url_for("mypage"))

--- a/database.py
+++ b/database.py
@@ -185,7 +185,21 @@ class DBhandler:
             print(f"Product {product_id} marked as sold to {buyer_id}.")
             return True
         return False
+    
+    def mark_item_as_unsold(self, product_id):
+        self.db.child("item").child(product_id).update({"state": "unsold", "buyerId": None})
 
+        # 구매자의 구매 내역에서 제거
+        purchase_entries = self.db.child("purchases").get().each()
+        if purchase_entries:
+            for entry in purchase_entries:
+                purchase = entry.val()
+                if purchase.get("productId") == product_id:
+                    self.db.child("purchases").child(entry.key()).remove()
+                    print(f"Product {product_id} marked as unsold and removed from purchase history.")
+                    return True
+        print(f"Product {product_id} marked as unsold but no purchase history found.")
+        return True  # 구매 내역이 없더라도 상태를 변경한 경우 True 반환
         
     # 사용자 정보 업데이트 함수 추가
     def update_user_info(self, user_id, new_email=None, new_phone=None):

--- a/database.py
+++ b/database.py
@@ -168,8 +168,7 @@ class DBhandler:
         print(f"Updated product {product_id} to {new_status}")
     
     def mark_item_as_sold(self, product_id, buyer_id):
-        # 상품 상태를 'sold'로 업데이트
-        self.db.child("item").child(product_id).update({"state": "sold", "buyerId": buyer_id})
+        self.db.child("item").child(product_id).update({"buyerId": buyer_id})
     
         # 구매자의 구매 내역에 추가
         purchase_info = self.db.child("item").child(product_id).get().val()
@@ -187,7 +186,7 @@ class DBhandler:
         return False
     
     def mark_item_as_unsold(self, product_id):
-        self.db.child("item").child(product_id).update({"state": "unsold", "buyerId": None})
+        self.db.child("item").child(product_id).update({"buyerId": None})
 
         # 구매자의 구매 내역에서 제거
         purchase_entries = self.db.child("purchases").get().each()
@@ -199,7 +198,7 @@ class DBhandler:
                     print(f"Product {product_id} marked as unsold and removed from purchase history.")
                     return True
         print(f"Product {product_id} marked as unsold but no purchase history found.")
-        return True  # 구매 내역이 없더라도 상태를 변경한 경우 True 반환
+        return True  # 구매 내역이 없더라도 buyerId를 제거한 경우 True 반환
         
     # 사용자 정보 업데이트 함수 추가
     def update_user_info(self, user_id, new_email=None, new_phone=None):


### PR DESCRIPTION
## 💻 작업 내용
- 판매 미완 토글 기능을 구현했습니다.
- 판매 완료 시 buyerId 추가 및 purchases 추가, 판매 미완으로 돌릴 시 buyerId None값으로 수정 및 purchases에서 삭제가 이루어집니다.

## ⭐ 리뷰 포인트
- 이전에 소정님이 판매 완료 pr 날려주신 것 보니 state도 sold로 변화하는데, 그렇게 되면 다시 판매 미완일 시 이전 state 값이 "중고물품", "새상품" 중 무엇인지 알고 되돌릴 수가 없어서 해당 방식 모두 이 pr에서 제거했습니다.
- 판매 완료인지 미완인지 item의 buyerId가 None인지 아닌지로 구분하도록 하겠습니다!

## 🐻 기타 사항
-
